### PR TITLE
refactor: update names of struct fields to be more consistent

### DIFF
--- a/src/rust/src/helpers/file.rs
+++ b/src/rust/src/helpers/file.rs
@@ -11,8 +11,8 @@ pub type Error = Box<dyn std::error::Error>;
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Metadata {
     pub blake3_checksum: String,
-    pub file_size_bytes: u64,
-    pub time_stamp: String,
+    pub size: u64,
+    pub add_time: String,
     pub message: String,
     pub saved_by: String
 }

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 struct RFile {
     relative_path: Option<String>,
     outcome: String,
-    file_size_bytes: Option<u64>,
+    size: Option<u64>,
     blake3_checksum: Option<String>,
     absolute_path: Option<String>,
     input: Option<String>,
@@ -23,7 +23,7 @@ struct RFile {
 struct RFileSuccess {
     relative_path: String,
     outcome: String,
-    file_size_bytes: u64,
+    size: u64,
     blake3_checksum: String,
     absolute_path: String,
 }
@@ -82,7 +82,7 @@ fn dvs_add_impl(files_string: Vec<String>, message: Nullable<&str>, strict: bool
             Ok(fi) => RFile{
                 relative_path: Some(fi.relative_path.display().to_string()),
                 outcome: fi.outcome.outcome_to_string(),
-                file_size_bytes: Some(fi.file_size_bytes),
+                size: Some(fi.size),
                 blake3_checksum: Some(fi.blake3_checksum.clone()),
                 absolute_path: Some(fi.absolute_path.display().to_string()),
                 input: None,
@@ -92,7 +92,7 @@ fn dvs_add_impl(files_string: Vec<String>, message: Nullable<&str>, strict: bool
             Err(e) => RFile{
                 relative_path: e.relative_path.clone().map(|p| p.to_string_lossy().to_string()),
                 outcome: Outcome::Error.outcome_to_string(),
-                file_size_bytes: None,
+                size: None,
                 blake3_checksum:  None,
                 absolute_path: e.absolute_path.clone().map(|p| p.to_string_lossy().to_string()),
                 input: Some(e.input.display().to_string()),
@@ -133,7 +133,7 @@ fn dvs_add_impl(files_string: Vec<String>, message: Nullable<&str>, strict: bool
                         RFileSuccess{
                             relative_path: res.relative_path.unwrap(),
                             outcome: res.outcome,
-                            file_size_bytes: res.file_size_bytes.unwrap(),
+                            size: res.size.unwrap(),
                             blake3_checksum: res.blake3_checksum.unwrap(),
                             absolute_path: res.absolute_path.unwrap(),
                         }
@@ -174,7 +174,7 @@ fn dvs_get_impl(files_string: Vec<String>, split_output: bool) -> Result<Robj> {
             Ok(fi) => RFile{
                 relative_path: Some(fi.relative_path.display().to_string()),
                 outcome: fi.outcome.outcome_to_string(),
-                file_size_bytes: Some(fi.file_size_bytes),
+                size: Some(fi.size),
                 absolute_path: Some(fi.absolute_path.display().to_string()),
                 blake3_checksum: Some(fi.blake3_checksum.clone()),
                 input: None,
@@ -184,7 +184,7 @@ fn dvs_get_impl(files_string: Vec<String>, split_output: bool) -> Result<Robj> {
             Err(e) => RFile{
                 relative_path: e.relative_path.clone().map(|p| p.to_string_lossy().to_string()),
                 outcome: Outcome::Error.outcome_to_string(),
-                file_size_bytes: None,
+                size: None,
                 absolute_path: e.absolute_path.clone().map(|p| p.to_string_lossy().to_string()),
                 blake3_checksum: None,
                 input: Some(e.input.display().to_string()),
@@ -225,7 +225,7 @@ fn dvs_get_impl(files_string: Vec<String>, split_output: bool) -> Result<Robj> {
                         RFileSuccess{
                             relative_path: res.relative_path.unwrap(),
                             outcome: res.outcome,
-                            file_size_bytes: res.file_size_bytes.unwrap(),
+                            size: res.size.unwrap(),
                             blake3_checksum: res.blake3_checksum.unwrap(),
                             absolute_path: res.absolute_path.unwrap(),
                         }
@@ -257,9 +257,9 @@ fn dvs_get_impl(files_string: Vec<String>, split_output: bool) -> Result<Robj> {
 struct RStatusFile {
     relative_path: Option<String>,
     status: String,
-    file_size_bytes: Option<u64>,
+    size: Option<u64>,
     blake3_checksum: Option<String>,
-    time_stamp: Option<String>,
+    add_time: Option<String>,
     saved_by: Option<String>,
     message: Option<String>,
     absolute_path: Option<String>,
@@ -273,8 +273,8 @@ struct RStatusFile {
 struct RStatusFileSuccess {
     relative_path: String,
     status: String,
-    file_size_bytes: u64,
-    time_stamp: String,
+    size: u64,
+    add_time: String,
     saved_by: String,
     message: String,
     blake3_checksum: String,
@@ -305,8 +305,8 @@ fn dvs_status_impl(files: Vec<String>, split_output: bool) -> Result<Robj> {
             Ok(fi) => RStatusFile{
                 relative_path: fi.relative_path.clone().map(|p| p.to_string_lossy().to_string()),
                 status: fi.status.outcome_to_string(),
-                file_size_bytes: Some(fi.file_size_bytes.clone()),
-                time_stamp: Some(fi.time_stamp.clone()),
+                size: Some(fi.size.clone()),
+                add_time: Some(fi.add_time.clone()),
                 saved_by: Some(fi.saved_by.clone()),
                 message: Some(fi.message.clone()),
                 absolute_path: fi.absolute_path.clone().map(|p| p.to_string_lossy().to_string()),
@@ -318,9 +318,9 @@ fn dvs_status_impl(files: Vec<String>, split_output: bool) -> Result<Robj> {
             Err(e) => RStatusFile{
                 relative_path: e.relative_path.clone().map(|p| p.to_string_lossy().to_string()),
                 status: Status::Error.outcome_to_string(),
-                file_size_bytes: None,
+                size: None,
                 message: None,
-                time_stamp: None,
+                add_time: None,
                 saved_by: None,
                 absolute_path: e.absolute_path.clone().map(|p| p.to_string_lossy().to_string()),
                 blake3_checksum: None,
@@ -362,10 +362,10 @@ fn dvs_status_impl(files: Vec<String>, split_output: bool) -> Result<Robj> {
                         RStatusFileSuccess{
                             relative_path: res.relative_path.unwrap(),
                             status: res.status,
-                            time_stamp: res.time_stamp.unwrap(),
+                            add_time: res.add_time.unwrap(),
                             saved_by: res.saved_by.unwrap(),
                             message: res.message.unwrap(),
-                            file_size_bytes: res.file_size_bytes.unwrap(),
+                            size: res.size.unwrap(),
                             blake3_checksum: res.blake3_checksum.unwrap(),
                             absolute_path: res.absolute_path.unwrap(),
                         }

--- a/src/rust/src/library/add.rs
+++ b/src/rust/src/library/add.rs
@@ -7,7 +7,7 @@ use file_owner::Group;
 pub struct AddedFile {
     pub relative_path: PathBuf,
     pub outcome: Outcome,
-    pub file_size_bytes: u64,
+    pub size: u64,
     pub blake3_checksum: String,
     pub absolute_path: PathBuf,
 }
@@ -77,7 +77,7 @@ fn add_file(local_path: &PathBuf, git_dir: &PathBuf, group: &Option<Group>, stor
                 relative_path: relative_path.clone(),
                 absolute_path: absolute_path.clone(),
                 outcome: Outcome::Present,
-                file_size_bytes: metadata.file_size_bytes,
+                size: metadata.size,
                 blake3_checksum: metadata.blake3_checksum,
             });
         }
@@ -96,8 +96,8 @@ fn add_file(local_path: &PathBuf, git_dir: &PathBuf, group: &Option<Group>, stor
     // create metadata
     let metadata = file::Metadata{
         blake3_checksum: blake3_checksum.clone(),
-        file_size_bytes,
-        time_stamp: Utc::now().format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string(),
+        size: file_size_bytes,
+        add_time: Utc::now().format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string(),
         message: message.clone(),
         saved_by: user_name
     };
@@ -133,7 +133,7 @@ fn add_file(local_path: &PathBuf, git_dir: &PathBuf, group: &Option<Group>, stor
             relative_path,
             absolute_path,
             outcome,
-            file_size_bytes,
+            size: file_size_bytes,
             blake3_checksum
         }
     )

--- a/src/rust/src/library/get.rs
+++ b/src/rust/src/library/get.rs
@@ -5,7 +5,7 @@ use crate::helpers::{config, copy, error::{BatchError, FileError}, file, hash, o
 pub struct RetrievedFile {
     pub relative_path: PathBuf,
     pub outcome: Outcome,
-    pub file_size_bytes: u64,
+    pub size: u64,
     pub absolute_path: PathBuf,
     pub blake3_checksum: String,
 }
@@ -74,7 +74,7 @@ pub fn get_file(local_path: &PathBuf, storage_dir: &PathBuf, git_dir: &PathBuf) 
             absolute_path: file::get_absolute_path(local_path)?,
             blake3_checksum: hash::get_file_hash(local_path)?,
             outcome,
-            file_size_bytes: file::get_file_size(local_path)?
+            size: file::get_file_size(local_path)?
         }
     )
 }

--- a/src/rust/src/library/status.rs
+++ b/src/rust/src/library/status.rs
@@ -6,8 +6,8 @@ use std::path::PathBuf;
 pub struct FileStatus {
     pub relative_path: Option<PathBuf>,
     pub status: Status,
-    pub file_size_bytes: u64,
-    pub time_stamp: String,
+    pub size: u64,
+    pub add_time: String,
     pub saved_by: String,
     pub message: String,
     pub absolute_path: Option<PathBuf>,
@@ -69,9 +69,9 @@ fn status_file(local_path: &PathBuf) -> std::result::Result<FileStatus, FileErro
             relative_path,
             absolute_path,
             status,
-            file_size_bytes: metadata.file_size_bytes,
+            size: metadata.size,
             blake3_checksum: metadata.blake3_checksum,
-            time_stamp: metadata.time_stamp,
+            add_time: metadata.add_time,
             saved_by: metadata.saved_by,
             message: metadata.message
         })


### PR DESCRIPTION
This PR makes some breaking changes to the output formats to simplify the naming a bit. 

we can simplify file_size_bytes to just size as we can document that the number corresponds to bytes + that is the only relevant. It also aligns with the common use of size in other linux utilities plus in `fs` for functions like `dir_info()`.

For the timestamp, this was already an unintentional breaking change from the storage spec from the v2 go implementation, which used timestamp instead of time_stamp. The time stamp is an ambiguous name, and therefore we are going to rename it to `add_time` similar to other time related modifiers often present such as modification_time, creation_time, etc for normal files.